### PR TITLE
Small changes in the README

### DIFF
--- a/apps/networking/ble-localization/onprem/install/README.md
+++ b/apps/networking/ble-localization/onprem/install/README.md
@@ -19,7 +19,7 @@ With sudo access on the UCS machine run:
 
      sh nfs-installation.sh
 
-### <a id=ucs-cluster-ip></a> Provide UCS Cluster IP
+### <a id=ucs-cluster-ip></a> Provide INGRESS IP
 
 	 $ sh nfs-installation.sh
 	 Provide INGRESS_IP (ex: 10.10.10.101)

--- a/apps/networking/ble-localization/onprem/notebook/README.md
+++ b/apps/networking/ble-localization/onprem/notebook/README.md
@@ -9,7 +9,11 @@ Then, serve and predict using the saved model.
 
 * Cisco UCS - C240
 
-### Install K8s, Kubeflow & NFS server(if not installed) 
+## Setup
+
+### Install K8s, Kubeflow & NFS server (if not installed)
+
+To install NFS server follow steps below.
 
 #### Retrieve Ingress IP
 
@@ -31,9 +35,9 @@ Use either of 'EXTERNAL-IP' or 'INTERNAL-IP' of any of the nodes based on which 
 
 This IP will be referred to as INGRESS_IP from here on.
 
-#### Installing K8s, KF, NFS servers, PVs and PVCs.
+#### Installing NFS server, PVs and PVCs.
 
-Follow the [steps](./../install/) to install K8s, KF, NFS servers, PVs and PVCs.
+Follow the [steps](./../install/) to install NFS server, PVs and PVCs.
 
 ### Create & Connect to Jupyter Notebook Server
 

--- a/apps/networking/ble-localization/onprem/notebook/README.md
+++ b/apps/networking/ble-localization/onprem/notebook/README.md
@@ -11,7 +11,7 @@ Then, serve and predict using the saved model.
 
 ## Setup
 
-### Install K8s, Kubeflow & NFS server (if not installed)
+### Install NFS server (if not installed)
 
 To install NFS server follow steps below.
 

--- a/apps/networking/ble-localization/onprem/pipelines/README.md
+++ b/apps/networking/ble-localization/onprem/pipelines/README.md
@@ -12,7 +12,7 @@ To train, serve and prodict  model  using kubeflow pipeline through jupyter-note
 
 ## Setup
 
-### Install K8s, Kubeflow & NFS server (if not installed)
+### Install NFS server (if not installed)
 
 To install NFS server follow steps below.
 

--- a/apps/networking/ble-localization/onprem/pipelines/README.md
+++ b/apps/networking/ble-localization/onprem/pipelines/README.md
@@ -1,4 +1,4 @@
-# BLE RSSI Location Prediction using Kubeflow Pipelines
+# BLERSSI Location Prediction using Kubeflow Pipelines
 
 ## What we're going to build
 
@@ -8,13 +8,13 @@ To train, serve and prodict  model  using kubeflow pipeline through jupyter-note
 
 ## Infrastructure Used
 
-Cisco UCS - C240
-
+* Cisco UCS - C240
 
 ## Setup
 
+### Install K8s, Kubeflow & NFS server (if not installed)
 
-### Install K8s, Kubeflow & NFS server
+To install NFS server follow steps below.
 
 #### Retrieve Ingress IP
 
@@ -36,9 +36,9 @@ Use either of 'EXTERNAL-IP' or 'INTERNAL-IP' of any of the nodes based on which 
 
 This IP will be referred to as INGRESS_IP from here on.
 
-#### Installing K8s, KF, NFS servers, PVs and PVCs.
+#### Installing NFS server, PVs and PVCs.
 
-Follow the [steps](./../install/) to install K8s, KF, NFS servers, PVs and PVCs.
+Follow the [steps](./../install/) to install NFS server, PVs and PVCs.
 
 ### Create Jupyter Notebook Server
 


### PR DESCRIPTION
I followed steps in the README across examples. I found few small things:

1. Let's be consistent with the name of BLERSSI across README.
2. On the step, when we install NFS, user must already installed K8S and Kubeflow. It points in the main page here: https://github.com/CiscoAI/cisco-kubeflow-starter-pack#installation 